### PR TITLE
feat: add springdoc dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'


### PR DESCRIPTION
Official Docs: https://springdoc.org/#Introduction
Add dependency: 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
How to open swagger-ui
- http://localhost:8080/swagger-ui/index.html
- http://localhost:8080/v3/api-docs